### PR TITLE
Replaces Vindicia::Util with ActiveSupport

### DIFF
--- a/lib/vindicia-api.rb
+++ b/lib/vindicia-api.rb
@@ -1,2 +1,3 @@
+require 'active_support/core_ext/string/conversions'
 require 'vindicia/config'
 require 'vindicia/model'

--- a/lib/vindicia/config.rb
+++ b/lib/vindicia/config.rb
@@ -1,5 +1,4 @@
 require 'singleton'
-require 'vindicia/util'
 
 module Vindicia
 
@@ -193,7 +192,7 @@ module Vindicia
     return false unless API_CLASSES[config.api_version]
   
     API_CLASSES[config.api_version].each_key do |vindicia_klass|
-      const_set(Vindicia::Util.camelize(vindicia_klass.to_s), 
+      const_set(vindicia_klass.to_s.camelize, 
         Class.new do
           include Vindicia::Model
 

--- a/lib/vindicia/model.rb
+++ b/lib/vindicia/model.rb
@@ -1,5 +1,4 @@
 require "savon"
-require "savon/core_ext/string"
 
 module Vindicia
 
@@ -46,7 +45,7 @@ module Vindicia
     
       def define_class_action(action)
         class_action_module.module_eval <<-CODE
-          def #{action.to_s.snakecase}(body = {}, &block)
+          def #{action.to_s.underscore}(body = {}, &block)
             client.request :tns, #{action.inspect} do
               soap.namespaces["xmlns:tns"] = vindicia_target_namespace
               http.headers["SOAPAction"] = vindicia_soap_action('#{action}')
@@ -56,7 +55,7 @@ module Vindicia
               block.call(soap, wsdl, http, wsse) if block
             end
           rescue Exception => e
-            rescue_exception(:#{action.to_s.snakecase}, e)
+            rescue_exception(:#{action.to_s.underscore}, e)
           end
         CODE
       end
@@ -90,7 +89,7 @@ module Vindicia
       end
       
       def vindicia_soap_action(action)
-        %{"#{vindicia_target_namespace}##{action.to_s.lower_camelcase}"}
+        %{"#{vindicia_target_namespace}##{action.to_s.camelize(:lower)}"}
       end
 
       def rescue_exception(action, error)

--- a/lib/vindicia/util.rb
+++ b/lib/vindicia/util.rb
@@ -1,8 +1,0 @@
-module Vindicia
-  module Util
-    # Taken from Rails 3.0.4 ActiveSupport::Inflector
-    def self.camelize(lower_case_and_underscored_word)
-      lower_case_and_underscored_word.to_s.gsub(/\/(.?)/) { "::#{$1.upcase}" }.gsub(/(?:^|_)(.)/) { $1.upcase }
-    end
-  end
-end

--- a/test/vindicia/config_test.rb
+++ b/test/vindicia/config_test.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'vindicia/util'
 
 class Vindicia::ConfigTest < Test::Unit::TestCase
 
@@ -8,7 +7,7 @@ class Vindicia::ConfigTest < Test::Unit::TestCase
       def self.clear_config
         if Vindicia.config.is_configured?
           Vindicia::API_CLASSES[Vindicia.config.api_version].each_key do |vindicia_klass|
-            Vindicia.send(:remove_const, Vindicia::Util.camelize(vindicia_klass.to_s).to_sym)
+            Vindicia.send(:remove_const, vindicia_klass.to_s.camelize.to_sym)
           end
         end
       end
@@ -88,7 +87,7 @@ class Vindicia::ConfigTest < Test::Unit::TestCase
     assert Vindicia.config.is_configured?
 
     Vindicia::API_CLASSES[good_api_version].each_key do |vindicia_klass|
-      assert Vindicia.const_get(Vindicia::Util.camelize(vindicia_klass.to_s))
+      assert Vindicia.const_get(vindicia_klass.to_s.camelize)
     end
   end
   

--- a/test/vindicia/model_test.rb
+++ b/test/vindicia/model_test.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'vindicia/util'
 require 'net/http'
 
 class Vindicia::ModelTest < Test::Unit::TestCase
@@ -9,7 +8,7 @@ class Vindicia::ModelTest < Test::Unit::TestCase
       def self.clear_config
         if Vindicia.config.is_configured?
           Vindicia::API_CLASSES[Vindicia.config.api_version].each_key do |vindicia_klass|
-            Vindicia.send(:remove_const, Vindicia::Util.camelize(vindicia_klass.to_s).to_sym)
+            Vindicia.send(:remove_const, vindicia_klass.to_s.camelize.to_sym)
           end
         end
       end
@@ -39,7 +38,7 @@ class Vindicia::ModelTest < Test::Unit::TestCase
   def test_should_define_api_methods_of_respective_vindicia_class_for_respective_api_version
     Vindicia::API_CLASSES[@good_api_version].each_key do |vindicia_klass_name|
 
-      vindicia_klass = Vindicia.const_get(Vindicia::Util.camelize(vindicia_klass_name.to_s))
+      vindicia_klass = Vindicia.const_get(vindicia_klass_name.to_s.camelize)
 
       Vindicia::API_CLASSES[@good_api_version][vindicia_klass_name].each do |api_method|
         assert vindicia_klass.respond_to?(api_method)

--- a/test/vindicia/util_test.rb
+++ b/test/vindicia/util_test.rb
@@ -1,8 +1,0 @@
-require 'helper'
-require 'vindicia/util'
-
-class Vindicia::UtilTest < Test::Unit::TestCase
-  def test_camelize_should_produce_camalcase_name_from_lowercase_underscore_name
-    assert_equal 'FooBarBaz', Vindicia::Util.camelize('foo_bar_baz')
-  end
-end

--- a/vindicia-api.gemspec
+++ b/vindicia-api.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency('savon')
+  gem.add_dependency('active_support')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('mocha')


### PR DESCRIPTION
Uses camelize and underscore methods. Savon got rid of lower_camelcase and the snake case
method was a bit odd, so replaced them with ActiveSupport's string conversion methods.
