### PR TITLE
Fix ActiveSupport Dependency

### DIFF
--- a/vindicia-api.gemspec
+++ b/vindicia-api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency('savon')
-  gem.add_dependency('active_support')
+  gem.add_dependency('activesupport')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('mocha')


### PR DESCRIPTION
0.0.5 introduced ActiveSupport to vindicia-api, but it was mistakenly linked to active_support,
which is a gem hardlocked to 3.0.0.  This uses the appropriate activesupport gem which eliminates
then dependency lock issue when working with Rails > 3.0.0.
