### PR TITLE
Froze Savon version

### DIFF
--- a/vindicia-api.gemspec
+++ b/vindicia-api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('savon')
+  gem.add_dependency('savon', '~> 1.2.0')
   gem.add_dependency('activesupport')
 
   gem.add_development_dependency('rake')


### PR DESCRIPTION
The Savon version used in the project no longer works. The ideal solution will be to rewrite the code to Savon 2.x, but for now we can just use an older version.
