### PR TITLE
added support for WebSession, escaping initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add something like the following to your environments or in an initializer:
 
 ```ruby
 Vindicia.configure do |config|
-  config.api_version = '3.6'
+  config.api_version = '4.2'
   config.login = 'your_login'
   config.password = 'your_password' 
   config.endpoint = 'https://soap.prodtest.sj.vindicia.com/soap.pl'
@@ -38,7 +38,15 @@ end
 
 You will want to modify the example above with which API version you are targeting, your login credentials, and the Vindicia endpoint you will be using.
 
-Current supported API versions are '3.5' and '3.6'.
+Current supported API versions are [ '3.5', '3.6', '3.7', '3.8', '3.9', '4.0', '4.1', '4.2' ].
+
+For a fuller understanding of the supported versions, classes, and methods, see
+Vindicia::API_CLASSES.  For instance, the list of versions may be introspected
+via the following:
+Vindicia::API_CLASSES.keys
+
+Likewise, the list of classes and their methods may be introspected via the following:
+Vindicia::API_CLASSES[version_number]
 
 Available Vindicia endpoints are:
 
@@ -51,14 +59,22 @@ After the Vindicia API has been configured, all Vindicia classes for the respect
 Parameters are passed as hashes, for example:
 
 ```ruby
-Vindicia::AutoBill.fetch_by_account(:account => { :merchantAccountId => id }
+auto_bill_response = Vindicia::AutoBill.fetch_by_account(:account => { :merchantAccountId => id })
+auto_bill = auto_bill_response.to_class
+if auto_bill.nil?
+  raise "Error fetching AutoBill by Account for merchantAccountId: '#{id}', fault: '#{auto_bill_response.soap_fault}', error: #{auto_bill_response.http_error}"
+end
 ```
 
 * Note that parameters must be specified in the same order as documented in Vindicia's developer documentation.
 
-## Bugs
+## Hacks
 
-* WebSession class is unsupported as it uses 'initialize' as an API call which is a ruby reserved word
+* WebSession class is supported in a hacky manner, as it uses 'initialize' as
+an API call which is a ruby reserved word.  An underscore is hence prepended to
+avoid the issue, so WebSession._initialize can be used to create a WebSession.
+* Savon 1 required jumping the same hoops repetitively to extract the class, so
+.to_class was extended to Savon::SOAP::Response .
 
 ## Contributing to vindicia-api
  
@@ -72,4 +88,4 @@ Vindicia::AutoBill.fetch_by_account(:account => { :merchantAccountId => id }
 
 ## Copyright
 
-Copyright (c) 2011-2013 Agora Games. See LICENSE.txt for further details.
+Copyright (c) 2011-2014 Agora Games. See LICENSE.txt for further details.

--- a/lib/vindicia-api.rb
+++ b/lib/vindicia-api.rb
@@ -1,3 +1,4 @@
 require 'active_support/core_ext/string/conversions'
 require 'vindicia/config'
 require 'vindicia/model'
+require 'vindicia/savon'

--- a/lib/vindicia/config.rb
+++ b/lib/vindicia/config.rb
@@ -25,7 +25,7 @@ module Vindicia
       :symantec=>[:add_auto_bill_item, :cancel_auto_bill, :cancel_pending_ar_txns, :delay_bill, :dispute_bill, :refund_ab_txns, :update_abs_account, :update_ab_product, :update_bp, :update_bp_and_catch_up_billing, :validate_bp, :fetch_b_ps_by_customer_guid, :lookup_transaction, :disable_billing_profile, :fetch_captured_transactions, :report_order_exception],
       :token=>[:update, :fetch],
       :transaction=>[:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth],
-      :web_session=>[:initialize, :finalize, :fetch_by_vid]
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     },
     "3.6" => {
       :account=>[:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit],
@@ -49,8 +49,7 @@ module Vindicia
       :symantec=>[:add_auto_bill_item, :cancel_auto_bill, :cancel_pending_ar_txns, :delay_bill, :dispute_bill, :refund_ab_txns, :update_abs_account, :update_ab_product, :update_bp, :update_bp_and_catch_up_billing, :validate_bp, :fetch_b_ps_by_customer_guid, :lookup_transaction, :disable_billing_profile, :fetch_captured_transactions, :report_order_exception],
       :token=>[:update, :fetch],
       :transaction=>[:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth],
-#      :web_session=>[:initialize, :finalize, :fetch_by_vid] # initialize is a ruby reserved word. need to refactor to get this one to work =( @TQ
-      :web_session=>[:finalize, :fetch_by_vid]
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     },
     "3.7" => {
       :account => [:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit, :make_payment, :reverse_payment, :is_entitled, :grant_entitlement, :revoke_entitlement, :extend_entitlement_to_date, :extend_entitlement_by_interval],
@@ -74,8 +73,7 @@ module Vindicia
       :symantec => [:add_auto_bill_item, :cancel_auto_bill, :cancel_pending_ar_txns, :delay_bill, :dispute_bill, :refund_ab_txns, :update_abs_account, :update_ab_product, :update_bp, :update_bp_and_catch_up_billing, :validate_bp, :fetch_b_ps_by_customer_guid, :lookup_transaction, :disable_billing_profile, :fetch_captured_transactions, :report_order_exception],
       :token => [:update, :fetch],
       :transaction => [:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth],
-#      :web_session=>[:initialize, :finalize, :fetch_by_vid] # initialize is a ruby reserved word. need to refactor to get this one to work =( @TQ
-      :web_session=> [:finalize, :fetch_by_vid]
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     },
     "3.8" => {
       :account => [:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit, :make_payment, :reverse_payment, :is_entitled, :grant_entitlement, :revoke_entitlement, :extend_entitlement_to_date, :extend_entitlement_by_interval],
@@ -100,8 +98,6 @@ module Vindicia
       :symantec => [:add_auto_bill_item, :cancel_auto_bill, :cancel_pending_ar_txns, :delay_bill, :dispute_bill, :refund_ab_txns, :update_abs_account, :update_ab_product, :update_bp, :update_bp_and_catch_up_billing, :validate_bp, :fetch_b_ps_by_customer_guid, :lookup_transaction, :disable_billing_profile, :fetch_captured_transactions, :report_order_exception],
       :token => [:update, :fetch],
       :transaction => [:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth],
-#      :web_session=>[:initialize, :finalize, :fetch_by_vid] # initialize is a ruby reserved word. need to refactor to get this one to work =( @TQ
-      :web_session=> [:finalize, :fetch_by_vid]
     },
     "3.9" => {
       :account => [:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :fetch_all_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit, :make_payment, :reverse_payment, :is_entitled, :grant_entitlement, :revoke_entitlement, :extend_entitlement_to_date, :extend_entitlement_by_interval],
@@ -126,8 +122,7 @@ module Vindicia
       :symantec => [:add_auto_bill_item, :cancel_auto_bill, :cancel_pending_ar_txns, :delay_bill, :dispute_bill, :refund_ab_txns, :update_abs_account, :update_ab_product, :update_bp, :update_bp_and_catch_up_billing, :validate_bp, :fetch_b_ps_by_customer_guid, :lookup_transaction, :disable_billing_profile, :fetch_captured_transactions, :report_order_exception],
       :token => [:update, :fetch],
       :transaction => [:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth],
-#      :web_session=>[:initialize, :finalize, :fetch_by_vid] # initialize is a ruby reserved word. need to refactor to get this one to work =( @TQ
-      :web_session=> [:finalize, :fetch_by_vid]
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     },
     "4.0" => {
       :account => [:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :fetch_all_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit, :make_payment, :reverse_payment, :is_entitled, :grant_entitlement, :revoke_entitlement, :extend_entitlement_to_date, :extend_entitlement_by_interval],
@@ -151,8 +146,7 @@ module Vindicia
       :refund => [:fetch_by_vid, :fetch_by_account, :fetch_by_transaction, :fetch_delta_since, :report, :perform],
       :token => [:update, :fetch],
       :transaction => [:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth, :finalize_boku_auth_capture],
-#      :web_session=>[:initialize, :finalize, :fetch_by_vid] # initialize is a ruby reserved word. need to refactor to get this one to work =( @TQ
-      :web_session=> [:finalize, :fetch_by_vid]
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     },
     "4.2" => {
       :account => [:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :fetch_all_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit, :make_payment, :reverse_payment, :is_entitled, :grant_entitlement, :revoke_entitlement, :extend_entitlement_to_date, :extend_entitlement_by_interval],
@@ -176,8 +170,7 @@ module Vindicia
       :refund => [:fetch_by_vid, :fetch_by_account, :fetch_by_transaction, :fetch_delta_since, :report, :perform],
       :token => [:update, :fetch],
       :transaction => [:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth, :finalize_boku_auth_capture, :finalize_customer_action, :address_and_sales_tax_from_pay_pal_order],
-#      :web_session=>[:initialize, :finalize, :fetch_by_vid] # initialize is a ruby reserved word. need to refactor to get this one to work =( @TQ
-      :web_session=> [:finalize, :fetch_by_vid]
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     }
   }
 

--- a/lib/vindicia/config.rb
+++ b/lib/vindicia/config.rb
@@ -98,6 +98,7 @@ module Vindicia
       :symantec => [:add_auto_bill_item, :cancel_auto_bill, :cancel_pending_ar_txns, :delay_bill, :dispute_bill, :refund_ab_txns, :update_abs_account, :update_ab_product, :update_bp, :update_bp_and_catch_up_billing, :validate_bp, :fetch_b_ps_by_customer_guid, :lookup_transaction, :disable_billing_profile, :fetch_captured_transactions, :report_order_exception],
       :token => [:update, :fetch],
       :transaction => [:fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_account, :fetch_by_merchant_transaction_id, :fetch_delta_since, :fetch_delta, :fetch_by_autobill, :fetch_search_page, :fetch_by_payment_method, :auth, :calculate_sales_tax, :capture, :cancel, :auth_capture, :report, :score, :finalize_pay_pal_auth],
+      :web_session=>[:_initialize, :finalize, :fetch_by_vid]
     },
     "3.9" => {
       :account => [:update, :stop_auto_billing, :update_payment_method, :fetch_by_merchant_account_id, :fetch_by_vid, :fetch_by_web_session_vid, :fetch_by_email, :fetch_by_payment_method, :token_balance, :token_transaction, :increment_tokens, :decrement_tokens, :transfer, :redeem_gift_card, :grant_credit, :revoke_credit, :fetch_credit_history, :fetch_all_credit_history, :add_children, :remove_children, :fetch_family, :transfer_credit, :make_payment, :reverse_payment, :is_entitled, :grant_entitlement, :revoke_entitlement, :extend_entitlement_to_date, :extend_entitlement_by_interval],

--- a/lib/vindicia/model.rb
+++ b/lib/vindicia/model.rb
@@ -44,7 +44,7 @@ module Vindicia
     private
     
       def define_class_action(action)
-        escaped_action = !action.to_s.start_with?('_') ? action.to_s : action[1..-1] #chomp leading _, if present
+        escaped_action = !action.to_s.start_with?('_') ? action : action[1..-1] #chomp leading _, if present
         class_action_module.module_eval <<-CODE
           def #{action.to_s.underscore}(body = {}, &block)
             client.request :tns, #{escaped_action.inspect} do

--- a/lib/vindicia/model.rb
+++ b/lib/vindicia/model.rb
@@ -44,11 +44,12 @@ module Vindicia
     private
     
       def define_class_action(action)
+        escaped_action = !action.to_s.start_with?('_') ? action.to_s : action[1..-1] #chomp leading _, if present
         class_action_module.module_eval <<-CODE
           def #{action.to_s.underscore}(body = {}, &block)
-            client.request :tns, #{action.inspect} do
+            client.request :tns, #{escaped_action.inspect} do
               soap.namespaces["xmlns:tns"] = vindicia_target_namespace
-              http.headers["SOAPAction"] = vindicia_soap_action('#{action}')
+              http.headers["SOAPAction"] = vindicia_soap_action('#{escaped_action}')
               soap.body = {
                 :auth => vindicia_auth_credentials
               }.merge(body)

--- a/lib/vindicia/savon.rb
+++ b/lib/vindicia/savon.rb
@@ -1,0 +1,11 @@
+module Savon
+  module SOAP
+    class Response
+      def self.to_class()
+        return nil if !success?
+        klass = to_hash
+        klass[klass.keys[0]][1]
+      end
+    end
+  end
+end

--- a/lib/vindicia/savon.rb
+++ b/lib/vindicia/savon.rb
@@ -1,11 +1,23 @@
 module Savon
   module SOAP
+    class ResponseError < StandardError
+    end
+
     class Response
-      def to_class()
-        return nil if !success?
+      def to_class(opts = {})
+        return if !success?
         klass = to_hash
         # drill down to envelope
         klass = klass[klass.keys[0]]
+
+        status_code = klass[:return][:return_code].to_i
+        if status_code != 200
+          if opts[:raise_on_error]
+            raise ResponseError.new("Soap Error: #{klass[:return][:return_string]}")
+          end
+          return
+        end
+        
         # drill down to payload, [0] is return, [1] is payload, [2] is xmlns
         klass[klass.keys[1]]
       end

--- a/lib/vindicia/savon.rb
+++ b/lib/vindicia/savon.rb
@@ -1,10 +1,13 @@
 module Savon
   module SOAP
     class Response
-      def self.to_class()
+      def to_class()
         return nil if !success?
         klass = to_hash
-        klass[klass.keys[0]][1]
+        # drill down to envelope
+        klass = klass[klass.keys[0]]
+        # drill down to payload, [0] is return, [1] is payload, [2] is xmlns
+        klass[klass.keys[1]]
       end
     end
   end

--- a/test/vindicia/model_test.rb
+++ b/test/vindicia/model_test.rb
@@ -55,4 +55,33 @@ class Vindicia::ModelTest < Test::Unit::TestCase
     assert resp.to_hash
     assert_equal '500', resp[:update_response][:return][:return_code]
   end
+
+  def test_should_support_ruby_keyword_actions
+    # this feature is used by WebSession, to support the initialize action, no huge rework, just escape codes
+    assert Vindicia.config.is_configured?
+
+    web_session = Vindicia::WebSession
+
+    # method is available to be called
+    web_session_methods = web_session.methods
+    assert web_session_methods.include?(:_initialize)
+
+    # method yields an action that is escaped
+    resp = web_session._initialize(:ipAddress => '124.23.210.175',
+                            :method => 'AutoBill_Update',
+                            :returnUrl => 'https://merchant.com/subscribe/success.php',
+                            :errorUrl => 'https://merchant.com/subscribe/failed.php',
+                            :privatePormValues => [
+                              { :name => 'Account_VID', :value => '36c8de2cb74b2c2b08b259cf231ac8d90d1bb3b8' },
+                              { :name => 'Product_merchantProductId', :value => 'StartWars II' },
+                              { :name => 'vin_BillingPlan_merchantBillingPlanId', :value => 'GoldAccess2010, PlatinumAccess2010' }
+                            ],
+                            :methodParamValues => [
+                              { :name => 'AutoBill_Update_minChargebackProbability', :value => '80' }
+                            ])
+    assert_not_nil resp
+    assert resp.to_hash
+    # the fact that the response is enveloped in the escaped form of the action is evidence that the action was properly mapped
+    assert_equal '403', resp[:initialize_response][:return][:return_code]
+  end
 end


### PR DESCRIPTION
Rather than reworking the savon integration tremendously, the approach was to escape the configured action, prepending an underscore.

The test asserts that the action is exposed via the method as configured and the action with the prepended underscore removed.
